### PR TITLE
Fix call on null object whilst role is without default store view

### DIFF
--- a/Plugin/Model/HideDefaultStoreCode.php
+++ b/Plugin/Model/HideDefaultStoreCode.php
@@ -37,8 +37,8 @@ class HideDefaultStoreCode
      */
     public function afterGetBaseUrl(\Magento\Store\Model\Store $subject, $url)
     {
-        if ($this->helper->isHideDefaultStoreCode()) {
-            $url = str_replace('/'.$this->storeManager->getDefaultStoreView()->getCode().'/','/', $url);
+        if ($this->helper->isHideDefaultStoreCode() && !is_null($this->storeManager->getDefaultStoreView())) {
+            $url = str_replace('/'.$this->storeManager->getDefaultStoreView()->getCode().'/', '/', $url);
         }
         return $url;
     }


### PR DESCRIPTION
This bug could happen in case Role Scope is changed to a/some specific stores, then a role/admin user doesn't have default store access.
an easy fix is to check if only when the default store view is not null then we can replace its code:
```
//HideDefaultStoreCode.php
public function afterGetBaseUrl(\Magento\Store\Model\Store $subject, $url)
    {
        if ($this->helper->isHideDefaultStoreCode() && !is_null($this->storeManager->getDefaultStoreView())) {
            $url = str_replace('/'.$this->storeManager->getDefaultStoreView()->getCode().'/', '/', $url);
        }
        return $url;
    }
```